### PR TITLE
fix broken build

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -10,7 +10,7 @@ _download_tgz "${FILE}" "${URL}" "${FOLDER}"
 pushd "target/${FOLDER}"
 PKG_CONFIG_PATH="${DEST}/lib/pkgconfig" \
   ./configure --dest-cpu=arm --dest-os=linux --prefix="${DEST}" \
-  --with-arm-float-abi=softfp \
+  --with-arm-float-abi=softfp
 make
 make install
 mv -vf "${DEST}/share/man" "${DEST}/"

--- a/app.sh
+++ b/app.sh
@@ -21,6 +21,7 @@ popd
 _build_certificates() {
 # update CA certificates on a Debian/Ubuntu machine:
 #sudo update-ca-certificates
+mkdir -p "${DEST}/etc/ssl/certs/"
 cp -vf /etc/ssl/certs/ca-certificates.crt "${DEST}/etc/ssl/certs/"
 ln -vfs certs/ca-certificates.crt "${DEST}/etc/ssl/cert.pem"
 }


### PR DESCRIPTION
the current `HEAD` of `master` (2c14bc9) would not build for me due to two issues:
- the `configure` script failed because the last argument was `make` due to an errant escaping of a line break. (fixed in 863c01c)
- the certificate copy failed because it was trying to copy files into a (deep) folder that didn't yet exist. (fixed in 97c788e)

verified successful via:

```
docker run -t -i droboports/compiler build https://github.com/blech75/nodejs#fix-broken-build
```

(requires latest docker-cross-compiler image with droboports/docker-cross-compiler#2 merged.)
